### PR TITLE
feat(plugin-webview): support domStorageAccess for ArkWeb DOM storage

### DIFF
--- a/crates/plugin-webview/README.md
+++ b/crates/plugin-webview/README.md
@@ -102,7 +102,7 @@ async fn composed_webview(app: &OpenHarmonyApp) -> Result<()> {
 }
 ```
 
-`WebviewCreateRequest` 支持 URL/HTML、`parent_node` 组合、样式、JavaScript 开关、devtools、
+`WebviewCreateRequest` 支持 URL/HTML、`parent_node` 组合、样式、JavaScript 开关、DOM storage、devtools、
 user agent、autoplay、document-start initialization scripts、headers 和 `transparent`。
 `transparent(true)` 是创建时语义：若没有显式 background color，ArkTS 使用透明背景；显式颜色优先。
 

--- a/crates/plugin-webview/src/lib.rs
+++ b/crates/plugin-webview/src/lib.rs
@@ -289,6 +289,9 @@ pub struct WebviewCreateRequest {
     pub html: Option<String>,
     pub style: WebviewStyle,
     pub javascript_enabled: Option<bool>,
+    /// Enables ArkWeb DOM storage (localStorage/sessionStorage), which ArkWeb disables by
+    /// default. The ArkTS host defaults this to enabled to match Android/iOS WebView behavior.
+    pub dom_storage_access: Option<bool>,
     pub devtools: Option<bool>,
     pub user_agent: Option<String>,
     pub autoplay: Option<bool>,
@@ -312,6 +315,7 @@ impl WebviewCreateRequest {
             html: None,
             style: WebviewStyle::default(),
             javascript_enabled: None,
+            dom_storage_access: None,
             devtools: None,
             user_agent: None,
             autoplay: None,
@@ -347,6 +351,12 @@ impl WebviewCreateRequest {
     /// Uses a transparent background when no explicit style background color was supplied.
     pub fn transparent(mut self, transparent: bool) -> Self {
         self.transparent = Some(transparent);
+        self
+    }
+
+    /// Enables ArkWeb DOM storage (localStorage/sessionStorage).
+    pub fn dom_storage_access(mut self, enabled: bool) -> Self {
+        self.dom_storage_access = Some(enabled);
         self
     }
 
@@ -914,6 +924,7 @@ mod tests {
         let request = WebviewCreateRequest::new("webview")
             .parent_node(7)
             .transparent(true)
+            .dom_storage_access(true)
             .url("https://example.test");
         assert_eq!(request.id, "webview");
         assert_eq!(request.parent_handle, Some(7));
@@ -921,6 +932,7 @@ mod tests {
         assert!(request.html.is_none());
         assert!(request.headers.is_none());
         assert_eq!(request.transparent, Some(true));
+        assert_eq!(request.dom_storage_access, Some(true));
     }
 
     #[test]

--- a/crates/plugin-webview/src/lib.rs
+++ b/crates/plugin-webview/src/lib.rs
@@ -289,8 +289,8 @@ pub struct WebviewCreateRequest {
     pub html: Option<String>,
     pub style: WebviewStyle,
     pub javascript_enabled: Option<bool>,
-    /// Enables ArkWeb DOM storage (localStorage/sessionStorage), which ArkWeb disables by
-    /// default. The ArkTS host defaults this to enabled to match Android/iOS WebView behavior.
+    /// Enables ArkWeb DOM storage (localStorage/sessionStorage). ArkWeb disables it by
+    /// default; when unset, DOM storage stays disabled, so callers opt in with `true`.
     pub dom_storage_access: Option<bool>,
     pub devtools: Option<bool>,
     pub user_agent: Option<String>,

--- a/demo/entry/src/main/cpp/types/libdemo_native/Index.d.ts
+++ b/demo/entry/src/main/cpp/types/libdemo_native/Index.d.ts
@@ -59,8 +59,8 @@ export interface WebviewCreateRequest {
   style: WebviewStyle;
   javascriptEnabled?: boolean;
   /**
-   * Enables ArkWeb DOM storage (localStorage/sessionStorage), which ArkWeb disables by
-   * default. The ArkTS host defaults this to enabled to match Android/iOS WebView behavior.
+   * Enables ArkWeb DOM storage (localStorage/sessionStorage). ArkWeb disables it by
+   * default; when unset, DOM storage stays disabled, so callers opt in with `true`.
    */
   domStorageAccess?: boolean;
   devtools?: boolean;

--- a/demo/entry/src/main/cpp/types/libdemo_native/Index.d.ts
+++ b/demo/entry/src/main/cpp/types/libdemo_native/Index.d.ts
@@ -58,6 +58,11 @@ export interface WebviewCreateRequest {
   html?: string;
   style: WebviewStyle;
   javascriptEnabled?: boolean;
+  /**
+   * Enables ArkWeb DOM storage (localStorage/sessionStorage), which ArkWeb disables by
+   * default. The ArkTS host defaults this to enabled to match Android/iOS WebView behavior.
+   */
+  domStorageAccess?: boolean;
   devtools?: boolean;
   userAgent?: string;
   autoplay?: boolean;

--- a/demo/entry/src/main/cpp/types/libdemo_sub_native/Index.d.ts
+++ b/demo/entry/src/main/cpp/types/libdemo_sub_native/Index.d.ts
@@ -50,6 +50,11 @@ export interface WebviewCreateRequest {
   html?: string;
   style: WebviewStyle;
   javascriptEnabled?: boolean;
+  /**
+   * Enables ArkWeb DOM storage (localStorage/sessionStorage), which ArkWeb disables by
+   * default. The ArkTS host defaults this to enabled to match Android/iOS WebView behavior.
+   */
+  domStorageAccess?: boolean;
   devtools?: boolean;
   userAgent?: string;
   autoplay?: boolean;

--- a/demo/entry/src/main/cpp/types/libdemo_sub_native/Index.d.ts
+++ b/demo/entry/src/main/cpp/types/libdemo_sub_native/Index.d.ts
@@ -51,8 +51,8 @@ export interface WebviewCreateRequest {
   style: WebviewStyle;
   javascriptEnabled?: boolean;
   /**
-   * Enables ArkWeb DOM storage (localStorage/sessionStorage), which ArkWeb disables by
-   * default. The ArkTS host defaults this to enabled to match Android/iOS WebView behavior.
+   * Enables ArkWeb DOM storage (localStorage/sessionStorage). ArkWeb disables it by
+   * default; when unset, DOM storage stays disabled, so callers opt in with `true`.
    */
   domStorageAccess?: boolean;
   devtools?: boolean;

--- a/plugins/webview/src/main/ets/WebviewPlugin.ets
+++ b/plugins/webview/src/main/ets/WebviewPlugin.ets
@@ -743,7 +743,7 @@ function BuildWebview(data: ManagedWebview) {
     .backgroundColor(data.style.backgroundColor ?? undefined)
     .visibility(data.style.visible === false ? Visibility.Hidden : Visibility.Visible)
     .javaScriptAccess(data.javascriptEnabled ?? true)
-    .domStorageAccess(data.domStorageAccess ?? true)
+    .domStorageAccess(data.domStorageAccess ?? false)
     .mediaPlayGestureAccess(data.autoplay === true ? false : true)
     .javaScriptOnDocumentStart(data.initializationScripts ?? [])
     .onControllerAttached(() => {

--- a/plugins/webview/src/main/ets/WebviewPlugin.ets
+++ b/plugins/webview/src/main/ets/WebviewPlugin.ets
@@ -78,6 +78,7 @@ interface WebviewCreatePayload {
   html?: string | null;
   style?: WebviewStyle | null;
   javascriptEnabled?: boolean | null;
+  domStorageAccess?: boolean | null;
   devtools?: boolean | null;
   userAgent?: string | null;
   autoplay?: boolean | null;
@@ -742,6 +743,7 @@ function BuildWebview(data: ManagedWebview) {
     .backgroundColor(data.style.backgroundColor ?? undefined)
     .visibility(data.style.visible === false ? Visibility.Hidden : Visibility.Visible)
     .javaScriptAccess(data.javascriptEnabled ?? true)
+    .domStorageAccess(data.domStorageAccess ?? true)
     .mediaPlayGestureAccess(data.autoplay === true ? false : true)
     .javaScriptOnDocumentStart(data.initializationScripts ?? [])
     .onControllerAttached(() => {
@@ -808,6 +810,7 @@ class WebviewSurface {
       url: payload.url,
       html: payload.html,
       javascriptEnabled: payload.javascriptEnabled,
+      domStorageAccess: payload.domStorageAccess,
       devtools: payload.devtools,
       userAgent: payload.userAgent,
       autoplay: payload.autoplay,


### PR DESCRIPTION
## Linked Issues

Closes #76

## Summary

Add a `dom_storage_access` option to `WebviewCreateRequest`, threaded through the
named N-API `ohos.webview.CreateRequest` into the ArkTS `WebviewPlugin`, so
callers can control ArkWeb's DOM storage (localStorage/sessionStorage).

## Motivation

ArkWeb disables DOM storage by default unless `.domStorageAccess(true)` is
explicitly set on the `Web()` component. The plugin never sets it, so:

- `window.localStorage` is `null`
- frontends throw `Cannot read properties of null` (white screen)
- token / settings / history cannot be persisted

Android and iOS WebViews enable DOM storage by default, so this is a platform
gap every webview consumer hits on OpenHarmony.

## Changes

- `crates/plugin-webview/src/lib.rs`: add `dom_storage_access: Option<bool>` field
  + `dom_storage_access(bool)` builder method to `WebviewCreateRequest`; extend the
  `create_request_retains_optional_value_semantics` test.
- `plugins/webview/src/main/ets/WebviewPlugin.ets`: add `domStorageAccess?` to
  `WebviewCreatePayload`, pass it through `WebviewSurface.create`, and call
  `.domStorageAccess(data.domStorageAccess ?? false)` in `BuildWebview`.
- `demo/.../types/*/Index.d.ts`: regenerate the `WebviewCreateRequest` declaration
  with the new field.

## Default behavior

Defaults to **disabled** (`?? false`), matching ArkWeb's official documented
behavior that DOM storage is off unless explicitly enabled. This is a **breaking
change** in behavior from the previous commit (which defaulted to `true`), but
aligns with the platform's native default and the official ArkWeb API
specification.

> Per [ArkWeb documentation](https://gitcode.com/openharmony/docs/blob/master/zh-cn/application-dev/reference/apis-arkweb/arkts-basic-components-web-attributes.md):
> > When `domStorageAccess` is not explicitly called, DOM Storage API is disabled by default.
> > Passing `undefined` or `null` results in `false`.

Callers that need DOM storage must explicitly opt in with
`.dom_storage_access(true)`.

## Breaking Change Note

This is a **behavioral breaking change** for existing consumers that rely on the
previous commit's default-enabled behavior. If you are upgrading from the
intermediate commit where default was `true`, please explicitly set
`.dom_storage_access(true)` in your `WebviewCreateRequest` to preserve
functionality.

If this breaking change is unacceptable, the default can be flipped back to
`true` in `WebviewPlugin.ets`.

## Verification

- `cargo check -p openharmony-ability-plugin-webview` passes.
- `cargo test -p openharmony-ability-plugin-webview --lib` (runs in CI with the
  OHOS toolchain; the host cannot link the OHOS `.lib` sys crates).
